### PR TITLE
Update R/plot.R - Add na.rm option to draw_means helper function

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -851,8 +851,8 @@ draw_means <- function(x, y, mean.smooth, mean.lwd,
           col = mean.pal[j], lty = mean.lty[j])
     }
     else {
-    mean.max[j] = max(mean.prev)
-    mean.min[j] = min(mean.prev)
+    mean.max[j] = max(mean.prev, na.rm = TRUE)
+    mean.min[j] = min(mean.prev, na.rm = TRUE)
     }
   }
   if(plot.means == 0 & mean.min_max == "max") {


### PR DESCRIPTION
The na.rm=TRUE option was not specified in the draw_means helper function when getting the min and max mean value for specified plot terms. As a result, an error message was received explaining that there was an unspecified ylim when plotting. NA values were being returned as the mean min and max before being set as the ylim lower and upper bound. This is not an issue in the draw_qnts as NA values are dealt with using na.rm in the main body of the function, and was only an issue in draw_means when nsims=1.