### PR TITLE
Adding in brackets that remove the pre-existing row names in the netw…

### DIFF
--- a/R/net.mod.simnet.R
+++ b/R/net.mod.simnet.R
@@ -94,7 +94,7 @@ resim_nets <- function(dat, at) {
     # Set up nwstats df
     if (dat$control$save.nwstats == TRUE) {
       dat$stats$nwstats <- rbind(dat$stats$nwstats,
-                                 tail(attributes(dat$nw)$stats, 1))
+                                 tail(attributes(dat$nw)$stats, 1)[,])
     }
 
     if (dat$control$delete.nodes == TRUE) {


### PR DESCRIPTION
…ork stats pulled out from dat$nw, so that the names will get assigned anew when rbinded to the existing stats, yielding consistent names.