### PR TITLE
Update plot.R - plot.netsim color palette

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -2214,8 +2214,11 @@ plot.netsim <- function(x, type = "epi", y, popfrac = FALSE, sim.lines = FALSE, 
     ## Color palettes ##
 
     # Main color palette
-    bpal <- brewer.pal(3, "Set1")
-    bpal <- c(bpal[2], bpal[1], bpal[3])
+    bpal <- c(brewer.pal(9, "Set1"), brewer.pal(8, "Set2"), brewer.pal(12, "Set3"))
+    bpal2 <- bpal[2]
+    bpal1 <- bpal[1]
+    bpal[1] <- bpal2
+    bpal[2] <- bpal1
 
     # Mean line
     if (missing(mean.col)) {


### PR DESCRIPTION
The plot.netsim function originally displayed three specified plot variables when mean.col and qnts.col were not user-specified due to hardcoding of the color palette for three colors.
Combined "Set1", "Set2", and "Set3" color brewer palettes for the fix to allow the max number of plotted variables to be 29 when user does not specify mean.col or qnts.col.

Resolves Issue #325 