### PR TITLE
Deduplication of the simulation code of netsim function

### DIFF
--- a/R/netsim.R
+++ b/R/netsim.R
@@ -135,7 +135,7 @@ netsim <- function(x, param, init, control) {
   if (ncores == 1) {
     for (s in 1:control$nsims) {
       # Run the simulation
-      dat <- netsim.loop(x, param, init, control, s)
+      dat <- netsim_loop(x, param, init, control, s)
 
       # Set output
       if (s == 1) {
@@ -156,7 +156,7 @@ netsim <- function(x, param, init, control) {
       control$currsim <- s
 
       # Run the simulation
-      dat <- netsim.loop(x, param, init, control, s)
+      dat <- netsim_loop(x, param, init, control, s)
 
       # Set output
       out <- saveout.net(dat, s = 1)
@@ -181,7 +181,7 @@ netsim <- function(x, param, init, control) {
 #'              simulation
 #' @inheritParams initialize.net
 #' @keywords internal
-netsim.loop <- function(x, param, init, control, s) {
+netsim_loop <- function(x, param, init, control, s) {
   ## Initialization Module
   if (!is.null(control[["initialize.FUN"]])) {
     dat <- do.call(control[["initialize.FUN"]], list(x, param, init, control, s))

--- a/R/netsim.R
+++ b/R/netsim.R
@@ -134,37 +134,8 @@ netsim <- function(x, param, init, control) {
 
   if (ncores == 1) {
     for (s in 1:control$nsims) {
-
-      ## Initialization Module
-      if (!is.null(control[["initialize.FUN"]])) {
-        dat <- do.call(control[["initialize.FUN"]], list(x, param, init, control, s))
-      }
-
-
-      ### TIME LOOP
-      if (control$nsteps > 1) {
-        for (at in max(2, control$start):control$nsteps) {
-
-          ## Module order
-          morder <- control$module.order
-          if (is.null(morder)) {
-            lim.bi.mods <- control$bi.mods[-which(control$bi.mods %in%
-                                                    c("initialize.FUN", "verbose.FUN"))]
-            morder <- c(control$user.mods, lim.bi.mods)
-          }
-
-          ## Evaluate modules
-          for (i in seq_along(morder)) {
-            dat <- do.call(control[[morder[i]]], list(dat, at))
-          }
-
-          ## Verbose module
-          if (!is.null(control[["verbose.FUN"]])) {
-            do.call(control[["verbose.FUN"]], list(dat, type = "progress", s, at))
-          }
-
-        }
-      }
+      # Run the simulation
+      dat <- netsim.loop(x, param, init, control, s)
 
       # Set output
       if (s == 1) {
@@ -184,36 +155,8 @@ netsim <- function(x, param, init, control) {
       control$nsims <- 1
       control$currsim <- s
 
-      ## Initialization Module
-      if (!is.null(control[["initialize.FUN"]])) {
-        dat <- do.call(control[["initialize.FUN"]], list(x, param, init, control, s))
-      }
-
-
-      ### TIME LOOP
-      if (control$nsteps > 1) {
-        for (at in max(2, control$start):control$nsteps) {
-
-          ## Module order
-          morder <- control$module.order
-          if (is.null(morder)) {
-            lim.bi.mods <- control$bi.mods[-which(control$bi.mods %in%
-                                                    c("initialize.FUN", "verbose.FUN"))]
-            morder <- c(control$user.mods, lim.bi.mods)
-          }
-
-          ## Evaluate modules
-          for (i in seq_along(morder)) {
-            dat <- do.call(control[[morder[i]]], list(dat, at))
-          }
-
-          ## Verbose module
-          if (!is.null(control[["verbose.FUN"]])) {
-            do.call(control[["verbose.FUN"]], list(dat, type = "progress", s, at))
-          }
-
-        }
-      }
+      # Run the simulation
+      dat <- netsim.loop(x, param, init, control, s)
 
       # Set output
       out <- saveout.net(dat, s = 1)
@@ -232,3 +175,42 @@ netsim <- function(x, param, init, control) {
   return(out)
 }
 
+#' @title Internal function running the network simulation loop
+#'
+#' @description This function run the initialization and simulation loop for one
+#'              simulation
+#' @inheritParams initialize.net
+#' @keywords internal
+netsim.loop <- function(x, param, init, control, s) {
+  ## Initialization Module
+  if (!is.null(control[["initialize.FUN"]])) {
+    dat <- do.call(control[["initialize.FUN"]], list(x, param, init, control, s))
+  }
+
+  ### TIME LOOP
+  if (control$nsteps > 1) {
+    for (at in max(2, control$start):control$nsteps) {
+
+      ## Module order
+      morder <- control$module.order
+      if (is.null(morder)) {
+        lim.bi.mods <- control$bi.mods[-which(control$bi.mods %in%
+                                              c("initialize.FUN", "verbose.FUN"))]
+        morder <- c(control$user.mods, lim.bi.mods)
+      }
+
+      ## Evaluate modules
+      for (i in seq_along(morder)) {
+        dat <- do.call(control[[morder[i]]], list(dat, at))
+      }
+
+      ## Verbose module
+      if (!is.null(control[["verbose.FUN"]])) {
+        do.call(control[["verbose.FUN"]], list(dat, type = "progress", s, at))
+      }
+
+    }
+  }
+
+  return(dat)
+}


### PR DESCRIPTION
Creation of a `netsim.loop` function containing the duplicated code for
mono and multicore in `netsim`.

Modified-by: Adrien Le Guillou <adrien.leguillou@gmail.com>