### PR TITLE
Update merge.netsim documentation

### DIFF
--- a/R/merge.R
+++ b/R/merge.R
@@ -96,9 +96,11 @@ merge.icm <- function(x, y, ...) {
 #' @param y Another \code{EpiModel} object of class \code{\link{netsim}},
 #'        with the identical model parameterization as \code{x}.
 #' @param keep.transmat If \code{TRUE}, keep the transmission matrices from the
-#'        original \code{x} and \code{y} elements.
+#'        original \code{x} and \code{y} elements. Note: transmission matrices
+#'        only saved when (\code{tergmLite == FALSE}).
 #' @param keep.network If \code{TRUE}, keep the \code{networkDynamic} objects
-#'        from the original \code{x} and \code{y} elements.
+#'        from the original \code{x} and \code{y} elements. Note: network
+#'        only saved when (\code{tergmLite == FALSE}).
 #' @param keep.nwstats If \code{TRUE}, keep the network statistics (as set by
 #'        the \code{nwstats.formula} parameter in \code{control.netsim}) from
 #'        the original \code{x} and \code{y} elements.


### PR DESCRIPTION
Update of merge.netsim documentation to make it clear when transmission matrices and network are saved as well as which parameter controls this behavior.