### PR TITLE
Add unit tests for tL and attribute copying

### DIFF
--- a/R/net.inputs.R
+++ b/R/net.inputs.R
@@ -346,7 +346,7 @@ init.net <- function(i.num, r.num, i.num.g2, r.num.g2,
 #'        this to \code{FALSE} is recommended when running models with new modules
 #'        specified.
 #' @param raw_output If \code{TRUE}, \code{netsim} will output a list of nestsim
-#'        Data (one per simulation) instead of a formatted \code{netsim} object.
+#'        data (one per simulation) instead of a formatted \code{netsim} object.
 #' @param ... Additional control settings passed to model.
 #'
 #' @details

--- a/man/control.net.Rd
+++ b/man/control.net.Rd
@@ -144,7 +144,7 @@ this to \code{FALSE} is recommended when running models with new modules
 specified.}
 
 \item{raw_output}{If \code{TRUE}, \code{netsim} will output a list of nestsim
-Data (one per simulation) instead of a formatted \code{netsim} object.}
+data (one per simulation) instead of a formatted \code{netsim} object.}
 
 \item{...}{Additional control settings passed to model.}
 }

--- a/man/merge.netsim.Rd
+++ b/man/merge.netsim.Rd
@@ -22,10 +22,12 @@
 with the identical model parameterization as \code{x}.}
 
 \item{keep.transmat}{If \code{TRUE}, keep the transmission matrices from the
-original \code{x} and \code{y} elements.}
+original \code{x} and \code{y} elements. Note: transmission matrices
+only saved when (\code{tergmLite == FALSE}).}
 
 \item{keep.network}{If \code{TRUE}, keep the \code{networkDynamic} objects
-from the original \code{x} and \code{y} elements.}
+from the original \code{x} and \code{y} elements. Note: network
+only saved when (\code{tergmLite == FALSE}).}
 
 \item{keep.nwstats}{If \code{TRUE}, keep the network statistics (as set by
 the \code{nwstats.formula} parameter in \code{control.netsim}) from

--- a/tests/testthat/test-attr-copy.R
+++ b/tests/testthat/test-attr-copy.R
@@ -1,0 +1,49 @@
+context("Attribute copying between network and data object attribute list")
+
+################################################################################
+
+test_that("Copying attributes from network to attribute list",{
+
+  num1 <- num2 <- 500
+  nw <- network.initialize(num1 + num2, directed = FALSE)
+  nw <- set.vertex.attribute(nw, "group", rep(1:2, each = num1))
+  nw <- set.vertex.attribute(nw, "race", sample(c("B","W"), num1+num2, replace = TRUE))
+  nw <- set.vertex.attribute(nw, "region", sample(1:4, num1+num2, replace = TRUE))
+  formation <- ~ edges + nodematch("group")
+  target.stats <- c(400, 0)
+  coef.diss <- dissolution_coefs(dissolution = ~ offset(edges), duration = 25)
+  est <- netest(nw, formation, target.stats, coef.diss)
+
+  init <- init.net(i.num = 50, i.num.g2 = 50)
+  param <- param.net(inf.prob = 0.1, inf.prob.g2 = 0.2,
+                     act.rate = 5)
+  control <- control.net(type = "SI", nsteps = 10, nsims = 2, tergmLite = FALSE,
+                         raw_output = TRUE, verbose = FALSE)
+
+  sim <- netsim(est, param, init, control)
+
+  # Character attribute
+  dat.attr <- prop.table(table(sim[[1]]$attr$race))
+  nw.attr <- prop.table(table(get.vertex.attribute(sim[[1]]$nw, "race")))
+
+  expect_equal(dat.attr, nw.attr)
+
+  # Numeric attribute
+  dat.attr <- prop.table(table(sim[[1]]$attr$region))
+  nw.attr <- prop.table(table(get.vertex.attribute(sim[[1]]$nw, "region")))
+
+  expect_equal(dat.attr, nw.attr)
+
+  # Second simulation
+  dat.attr <- prop.table(table(sim[[2]]$attr$race))
+  nw.attr <- prop.table(table(get.vertex.attribute(sim[[2]]$nw, "race")))
+
+  expect_equal(dat.attr, nw.attr)
+
+  dat.attr <- prop.table(table(sim[[2]]$attr$region))
+  nw.attr <- prop.table(table(get.vertex.attribute(sim[[2]]$nw, "region")))
+
+  expect_equal(dat.attr, nw.attr)
+
+
+})

--- a/tests/testthat/test-net-tergmLite.R
+++ b/tests/testthat/test-net-tergmLite.R
@@ -372,30 +372,6 @@ test_that("tergmLite: 2G, Open", {
 
 })
 
-test_that("tergmLite: Attribute copying from network <--> attr. list",{
-
-  num1 <- num2 <- 500
-  nw <- network.initialize(num1 + num2, directed = FALSE)
-  nw <- set.vertex.attribute(nw, "group", rep(1:2, each = num1))
-  nw <- set.vertex.attribute(nw, "race", sample(c("B","W"), num1+num2, replace = TRUE))
-  formation <- ~ edges + nodematch("group")
-  target.stats <- c(400, 0)
-  coef.diss <- dissolution_coefs(dissolution = ~ offset(edges), duration = 25, d.rate = 0.005)
-  est <- netest(nw, formation, target.stats, coef.diss)
-
-  param <- param.net(inf.prob = 0.1, inf.prob.g2 = 0.2,
-                     act.rate = 1, a.rate = 0.005, a.rate.g2 = 0.005,
-                     di.rate = 0.005, ds.rate = 0.005,
-                     di.rate.g2 = 0.005, ds.rate.g2 = 0.005,
-                     dr.rate = 0.005, dr.rate.g2 = 0.005,
-                     rec.rate = 0.005, rec.rate.g2 = 0.005)
-  init <- init.net(i.num = 10, i.num.g2 = 10, r.num = 5, r.num.g2 = 5)
-
-  control <- control.net(type = "SIR", nsteps = 20
-
-                         )
-})
-
 
 test_that("tergmLite: Expected Output", {
 


### PR DESCRIPTION
Adds unit tests for basic tergmLite usage as well as for attribute copying between network and data attribute lists.