### PR TITLE
Update to print.netsim.

### DIFF
--- a/R/print.r
+++ b/R/print.r
@@ -159,7 +159,7 @@ print.netsim <- function(x, formation.stats = FALSE, ...) {
 
   cat("\nModel Functions")
   cat("\n-----------------------\n")
-  for (i in 1:length(x$control$f.args)){
+  for (i in 1:length(x$control$f.args)) {
     (cat(x$control$f.names[i],"=",x$control$f.args[i],"\n"))
   }
   #cat("\n")


### PR DESCRIPTION
Output from `print.netsim` has been updated to be more flexible and account for base and user extended modules. Previous versions of pulling function names was largely hard coded; this has been completely removed. Now, `f.args` and `f.names` are pulled during `control.net` and updated during `crosscheck.net`. If any functions are missing (NA in `f.args`) these are dropped, maintaining those functions present in control inputs. Note: any user defined function names are parsed as `function` off of `function.FUN`.

Addresses #431 .