### PR TITLE
Allow saving of transmission matrix

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -165,16 +165,11 @@ get_transmat <- function(x, sim = 1) {
     stop("x must be of class netsim", call. = FALSE)
   }
 
-  if (x$control$tergmLite == TRUE) {
-    stop("transmat not saved when 'tergmLite == TRUE', check control.net settings",
-         call. = FALSE)
-  }
-
   if (sim > x$control$nsims) {
     stop("Specify sim between 1 and ", x$control$nsims, call. = FALSE)
   }
 
-  if (x$control$tergmLite == TRUE  || is.null(x$stats$transmat)) {
+  if (x$control$save.transmat == FALSE || is.null(x$stats$transmat)) {
     stop("transmat not saved in netsim object, check control.net settings",
          call. = FALSE)
   }

--- a/R/merge.R
+++ b/R/merge.R
@@ -97,7 +97,7 @@ merge.icm <- function(x, y, ...) {
 #'        with the identical model parameterization as \code{x}.
 #' @param keep.transmat If \code{TRUE}, keep the transmission matrices from the
 #'        original \code{x} and \code{y} elements. Note: transmission matrices
-#'        only saved when (\code{tergmLite == FALSE}).
+#'        only saved when (\code{save.transmat == TRUE}).
 #' @param keep.network If \code{TRUE}, keep the \code{networkDynamic} objects
 #'        from the original \code{x} and \code{y} elements. Note: network
 #'        only saved when (\code{tergmLite == FALSE}).

--- a/R/net.inputs.R
+++ b/R/net.inputs.R
@@ -342,6 +342,8 @@ init.net <- function(i.num, r.num, i.num.g2, r.num.g2,
 #' @param save.nwstats If \code{TRUE}, save network statistics in a data frame.
 #'        The statistics to be saved are specified in the \code{nwstats.formula}
 #'        argument.
+#' @param save.transmat If \code{TRUE}, complete transmission matrix is saved at
+#'        simulation end. Default of \code{TRUE}.
 #' @param nwstats.formula A right-hand sided ERGM formula that includes network
 #'        statistics of interest, with the default to the formation formula terms.
 #' @param save.other A vector of elements on the \code{dat} master data list
@@ -436,6 +438,7 @@ control.net <- function(type,
                         set.control.ergm,
                         set.control.stergm,
                         save.nwstats = TRUE,
+                        save.transmat = TRUE,
                         nwstats.formula = "formation",
                         save.other,
                         verbose = TRUE,

--- a/R/net.inputs.R
+++ b/R/net.inputs.R
@@ -486,11 +486,11 @@ control.net <- function(type,
          call. = FALSE)
   }
 
-  if ("save.network" %in% names(dot.args) || "save.transmat" %in% names(dot.args)) {
+  if ("save.network" %in% names(dot.args)) {
     p$tergmLite <- FALSE
-    stop("EpiModel 2.0+ has integrated options for saving of the network object and transmission ",
-         "matrix into control.net setting tergmLite: if FALSE, these are saved automatically; ",
-         "if TRUE, they are not saved. Update your code accordingly.",
+    stop("EpiModel 2.0+ has integrated options for saving of the network
+          object in control.net parameter tergmLite: if FALSE, this are
+          saved; if TRUE, they are not saved.",
          call. = FALSE)
   }
 

--- a/R/saveout.R
+++ b/R/saveout.R
@@ -143,7 +143,7 @@ saveout.net <- function(dat, s, out = NULL) {
       out$stats$nwstats <- list(dat$stats$nwstats)
     }
 
-    if (dat$control$tergmLite == FALSE) {
+    if (dat$control$save.transmat == TRUE) {
       if (!is.null(dat$stats$transmat)) {
         row.names(dat$stats$transmat) <- 1:nrow(dat$stats$transmat)
         out$stats$transmat <- list(dat$stats$transmat)
@@ -172,7 +172,7 @@ saveout.net <- function(dat, s, out = NULL) {
       out$stats$nwstats[[s]] <- dat$stats$nwstats
     }
 
-    if (dat$control$tergmLite == FALSE) {
+    if (dat$control$save.transmat == TRUE) {
       if (!is.null(dat$stats$transmat)) {
         row.names(dat$stats$transmat) <- 1:nrow(dat$stats$transmat)
         out$stats$transmat[[s]] <- dat$stats$transmat
@@ -203,7 +203,7 @@ saveout.net <- function(dat, s, out = NULL) {
       names(out$stats$nwstats) <- simnames
     }
 
-    if (dat$control$tergmLite == FALSE) {
+    if (dat$control$save.transmat == TRUE) {
       names(out$stats$transmat) <- simnames[1:length(out$stats$transmat)]
       names(out$network) <- simnames
     }

--- a/man/control.net.Rd
+++ b/man/control.net.Rd
@@ -27,6 +27,7 @@ control.net(
   set.control.ergm,
   set.control.stergm,
   save.nwstats = TRUE,
+  save.transmat = TRUE,
   nwstats.formula = "formation",
   save.other,
   verbose = TRUE,
@@ -120,6 +121,9 @@ this parameter.}
 \item{save.nwstats}{If \code{TRUE}, save network statistics in a data frame.
 The statistics to be saved are specified in the \code{nwstats.formula}
 argument.}
+
+\item{save.transmat}{If \code{TRUE}, complete transmission matrix is saved at
+simulation end. Default of \code{TRUE}.}
 
 \item{nwstats.formula}{A right-hand sided ERGM formula that includes network
 statistics of interest, with the default to the formation formula terms.}

--- a/man/merge.netsim.Rd
+++ b/man/merge.netsim.Rd
@@ -23,7 +23,7 @@ with the identical model parameterization as \code{x}.}
 
 \item{keep.transmat}{If \code{TRUE}, keep the transmission matrices from the
 original \code{x} and \code{y} elements. Note: transmission matrices
-only saved when (\code{tergmLite == FALSE}).}
+only saved when (\code{save.transmat == TRUE}).}
 
 \item{keep.network}{If \code{TRUE}, keep the \code{networkDynamic} objects
 from the original \code{x} and \code{y} elements. Note: network

--- a/tests/testthat/test-net-tergmLite.R
+++ b/tests/testthat/test-net-tergmLite.R
@@ -401,14 +401,14 @@ test_that("tergmLite: Expected Output", {
   param <- param.net(inf.prob = 0.1, act.rate = 5)
   init <- init.net(i.num = 10)
   control <- control.net(type = "SI", nsteps = 20, nsims = 1, ncores = 1,
-                         tergmLite = FALSE)
+                         tergmLite = FALSE, save.transmat = TRUE)
 
   sim <- netsim(est, param, init, control)
 
   expect_true(length(sim$stats$transmat) == 1)
 
   control <- control.net(type = "SI", nsteps = 20, nsims = 1, ncores = 1,
-                         tergmLite = TRUE)
+                         tergmLite = TRUE, save.transmat = FALSE)
 
   sim <- netsim(est, param, init, control)
 

--- a/tests/testthat/test-transmat-dendo.R
+++ b/tests/testthat/test-transmat-dendo.R
@@ -195,19 +195,3 @@ test_that("plot.transmat", {
   # plot(tm, style = "gv_tree")
   plot(tm, style = "transmissionTimeline")
 })
-
-test_that("'tergmLite == TRUE' correctly errors", {
-  skip_on_cran()
-  nw <- network_initialize(n = 100)
-  formation <- ~edges
-  target.stats <- 50
-  coef.diss <- dissolution_coefs(dissolution = ~offset(edges), duration = 10)
-  est1 <- netest(nw, formation, target.stats, coef.diss, verbose = FALSE)
-  param <- param.net(inf.prob = 1)
-  init <- init.net(i.num = 1)
-  control <- control.net(type = "SI", nsteps = 100, nsims = 1, verbose = FALSE,
-                         tergmLite = TRUE)
-  mod2 <- netsim(est1, param, init, control)
-  expect_error(get_transmat(mod2),"transmat not saved when 'tergmLite == TRUE', check control.net settings")
-})
-


### PR DESCRIPTION
Closes #451

EpiModel updated to allow saving of transmission matrix independent of tergmLite setting:

```
num <- 100
nw <- network_initialize(num)
coef.diss <- dissolution_coefs(dissolution = ~offset(edges),
                               duration = 20)
est <- netest(nw, formation = ~edges, target.stats = 40, coef.diss)

param <- param.net(inf.prob = 0.4, act.rate = 1)
init <- init.net(i.num = 10)
control <- control.net(type = "SI", nsteps = 10, resimulate.network = TRUE,
                       tergmLite = TRUE, save.transmat = TRUE)
```
