### PR TITLE
eliminate low-level reference in tergmLite

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,4 +60,4 @@ VignetteBuilder: knitr
 LinkingTo: ergm
 RoxygenNote: 7.1.1
 Encoding: UTF-8
-    
+Remotes: github::statnet/tergmLite@top_level_simulate

--- a/R/net.mod.nwupdate.R
+++ b/R/net.mod.nwupdate.R
@@ -78,8 +78,8 @@ nwupdate.net <- function(dat, at) {
       dat$el[[1]] <- delete_vertices(dat$el[[1]], departures)
 
       if (dat$control$tergmLite.track.duration) {
-        dat$p[[1]]$state$nw0 %n% "lasttoggle" <-
-          delete_vertices(dat$p[[1]]$state$nw0 %n% "lasttoggle", departures)
+        dat$nw[[1]] %n% "lasttoggle" <-
+          delete_vertices(dat$nw[[1]] %n% "lasttoggle", departures)
       }
     }
   }

--- a/R/net.mod.simnet.R
+++ b/R/net.mod.simnet.R
@@ -195,37 +195,38 @@ resim_nets <- function(dat, at) {
 
     # networkLite/tergmLite Method
     if (tergmLite == TRUE) {
-
-      dat <- tergmLite::updateModelTermInputs(dat)
-
-      if (isTERGM == TRUE) {
-        rv <- tergmLite::simulate_network(state = dat$p[[1]]$state,
-                                          coef = c(nwparam$coef.form,
-                                                   nwparam$coef.diss$coef.adj),
-                                          control = dat$control$mcmc.control[[1]],
-                                          save.changes = TRUE)
-        dat$el[[1]] <- rv$el
-
-        if (tergmLite.track.duration == TRUE) {
-          dat$p[[1]]$state$nw0 %n% "time" <- rv$state$nw0 %n% "time"
-          dat$p[[1]]$state$nw0 %n% "lasttoggle" <- rv$state$nw0 %n% "lasttoggle"
-        }
-      } else {
-        rv <- tergmLite::simulate_ergm(state = dat$p[[1]]$state,
-                                       coef = nwparam$coef.form,
-                                       control = dat$control$mcmc.control[[1]])
-
-        dat$el[[1]] <- rv$el
+      nwL <- networkLite(dat$el[[1]], dat$attr)
+      if (tergmLite.track.duration == TRUE) {
+        nwL %n% "time" <- dat$nw[[1]] %n% "time"
+        nwL %n% "lasttoggle" <- dat$nw[[1]] %n% "lasttoggle"
       }
 
+      if (isTERGM == TRUE) {
+        dat$nw[[1]] <- simulate(nwL ~ Form(nwparam$formation) + Persist(nwparam$coef.diss$dissolution),
+                                coef = c(nwparam$coef.form, nwparam$coef.diss$coef.adj),
+                                constraints = nwparam$constraints,
+                                time.start = at,
+                                time.slices = 1,
+                                time.offset = 0,
+                                control = dat$control$mcmc.control[[1]],
+                                output = "final",
+                                dynamic = TRUE)
+      } else {
+        dat$nw[[1]] <- simulate(object = nwparam$formation,
+                                basis = nwL,
+                                coef = nwparam$coef.form,
+                                constraints = nwparam$constraints,
+                                control = dat$control$mcmc.control[[1]],
+                                dynamic = FALSE,
+                                nsim = 1,
+                                output = "network")
+      }
+
+      dat$el[[1]] <- as.edgelist(dat$nw[[1]])
+
       if (save.nwstats == TRUE) {
-        nwL <- tergmLite::networkLite(dat$el[[1]], dat$attr)
-        if (tergmLite.track.duration == TRUE) {
-          nwL %n% "time" <- dat$p[[1]]$state$nw0 %n% "time"
-          nwL %n% "lasttoggle" <- dat$p[[1]]$state$nw0 %n% "lasttoggle"
-        }
         nwstats <- summary(dat$control$nwstats.formulas[[1]],
-                           basis = nwL,
+                           basis = dat$nw[[1]],
                            term.options = dat$control$mcmc.control[[1]]$term.options,
                            dynamic = isTERGM)
         keep.cols <- which(!duplicated(names(nwstats)))

--- a/R/net.mod.simnet.R
+++ b/R/net.mod.simnet.R
@@ -205,9 +205,9 @@ resim_nets <- function(dat, at) {
         dat$nw[[1]] <- simulate(nwL ~ Form(nwparam$formation) + Persist(nwparam$coef.diss$dissolution),
                                 coef = c(nwparam$coef.form, nwparam$coef.diss$coef.adj),
                                 constraints = nwparam$constraints,
-                                time.start = at,
+                                time.start = at - 1, # should be the time stamp on the nwL if we are tracking duration
                                 time.slices = 1,
-                                time.offset = 0,
+                                time.offset = 1, # default value
                                 control = dat$control$mcmc.control[[1]],
                                 output = "final",
                                 dynamic = TRUE)

--- a/tests/testthat/test-netstats.R
+++ b/tests/testthat/test-netstats.R
@@ -89,3 +89,30 @@ test_that("nw stats in tergmLite", {
                              "nodefactor.status.s", "nodematch.status"))
   expect_equal(dim(nws), c(5, 5))
 })
+
+test_that("tergm and tergmLite produce equal non-durational statistics", {
+  set.seed(0)
+  control <- control.net(type = NULL, 
+                         nsims = 1, 
+                         nsteps = 10, 
+                         ncores = 1, 
+                         verbose = FALSE, 
+                         resimulate.network = TRUE, 
+                         nwstats.formula = ~edges + concurrent + isolates + nodemix("status"))  
+  mod1 <- netsim(est, param, init, control)
+  a <- mod1$stats$nwstats[[1]][[1]]
+  
+  set.seed(0)
+  control <- control.net(type = NULL, 
+                         nsims = 1, 
+                         nsteps = 10, 
+                         ncores = 1, 
+                         verbose = FALSE, 
+                         resimulate.network = TRUE, 
+                         nwstats.formula = ~edges + concurrent + isolates + nodemix("status"), 
+                         tergmLite = TRUE)  
+  mod2 <- netsim(est, param, init, control)
+  b <- mod2$stats$nwstats[[1]][[1]]
+    
+  expect_equal(a,b)
+})


### PR DESCRIPTION
references statnet/tergmLite#51, statnet/tergmLite#54

I am seeing < 5% mean runtime differences for the netsim call in the EpiModelHIV.R example in tergmLite on both unix and windows (with length of the simulation increased to 50 years)

requires minor updates to EpiModelHIV@CombPrev-dev which I will push after this and statnet/tergmLite#54 are merged

temporarily induces dependence on github version of tergmLite, but we can merge the rest of tergmLite into EpiModel shortly (and move networkLites into a lower package at some point later, if we want to), so that dependence will be transient