### PR TITLE
 Allow random parameters to be generated from correlated distribution (fixes #533) 

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@ inst/EpiModel2/*.xlsx
 inst/EpiModel2/*.png
 .github
 ^\.github$
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ vignettes/Intro.R
 *.html
 tests/*.pdf
 tests/testthat/Rplots.pdf
+inst/doc
+/doc/
+/Meta/

--- a/R/net.inputs.R
+++ b/R/net.inputs.R
@@ -1,4 +1,3 @@
-
 #' @title Epidemic Parameters for Stochastic Network Models
 #'
 #' @description Sets the epidemic parameters for stochastic network models
@@ -358,10 +357,27 @@ param_random <- function(values, prob = NULL) {
 #' The function used inside \code{random_params} must be 0 argument functions
 #' returning a valid value for the parameter with the same name.
 #'
+#' @section \code{param_random_set}:
+#' The \code{random_params} list can optionnally contain a
+#' \code{param_random_set} element. It must be a \code{data.frame} of possible
+#' values to be used as parameters.
+#'
+#' The column names must correspond either to:
+#' the name of one parameter if this parameter is of size 1 or the name of the
+#' parameter with "_1", "_2", "_N" with the second part being the position of
+#' the value for a parameter of size > 1. This means that the parameter names
+#' cannot contain any underscore "_" if you indend to use \code{param_random_set}
+#'
+#' The point of the \code{param_random_set} \code{data.frame} is to allow the
+#' random parameters to be correlated. To achieve this, a whole row of the
+#' \code{data.frame} is selected for each simulation.
+#'
 #' @export
 #'
 #' @examples
 #' \dontrun{
+#'
+#' ## Example with only the generator function
 #'
 #' # Define random parameter list
 #' my_randoms <- list(
@@ -382,7 +398,42 @@ param_random <- function(values, prob = NULL) {
 #' # therefore produced.
 #' param <- param.net(tx.prob = 0.3, random.params = my_randoms)
 #'
-
+#'
+#' # Parameters are drawn automatically in netsim by calling the function
+#' # within netsim_loop. Demonstrating draws here but this is not used by
+#' # end user.
+#' paramDraw <- generate_random_params(param, verbose = TRUE)
+#' paramDraw
+#'
+#'
+#' ## Addition of the `param_random_set` `data.frame`
+#'
+#' # This function will generate sets of correlated parameters
+#'  generate_correlated_params <- function() {
+#'    param.unique <- runif(1)
+#'    param.set.1 <- param.unique + runif(2)
+#'    param.set.2 <- param.unique * rnorm(3)
+#'
+#'    return(list(param.unique, param.set.1, param.set.2))
+#'  }
+#'
+#'  # Data.frame set of random parameters :
+#'  correlated_params <- t(replicate(10, unlist(generate_correlated_params())))
+#'  correlated_params <- as.data.frame(correlated_params)
+#'  colnames(correlated_params) <- c(
+#'    "param.unique",
+#'    "param.set.1_1", "param.set.1_2",
+#'    "param.set.2_1", "param.set.2_2", "param.set.2_3"
+#'  )
+#'
+#' # Define random parameter list with the `param_random_set` element
+#' my_randoms <- list(
+#'   act.rate = param_random(c(0.25, 0.5, 0.75)),
+#'   param_random_set = correlated_params
+#' )
+#'
+#' # Parameter model with fixed and random parameters
+#' param <- param.net(inf.prob = 0.3, random.params = my_randoms)
 #'
 #' # Parameters are drawn automatically in netsim by calling the function
 #' # within netsim_loop. Demonstrating draws here but this is not used by
@@ -391,7 +442,6 @@ param_random <- function(values, prob = NULL) {
 #' paramDraw
 #'
 #' }
-#'
 generate_random_params <- function(param, verbose = FALSE) {
   if (is.null(param$random.params) || length(param$random.params) == 0) {
     return(param)

--- a/R/print.r
+++ b/R/print.r
@@ -316,6 +316,7 @@ print.param.net <- function(x, ...) {
     pToPrint <- pToPrint[! names(x)[pToPrint] %in% names(rng_values)]
   } else if (randoms[1] %in% names(x)) {
     rng_defs <- names(x[[randoms[1]]])
+    pToPrint <- pToPrint[! names(x)[pToPrint] %in% rng_defs]
   }
 
   cat("Fixed Parameters")
@@ -329,7 +330,11 @@ print.param.net <- function(x, ...) {
     cat("\n(Not drawn yet)")
     cat("\n---------------------------\n")
     for (prm in rng_defs) {
-      cat(prm, " = <function>\n")
+      if (prm == "param_random_set") {
+        cat(prm, "= <data.frame> ( dimensions:", dim(x$random.param$param_random_set), ")\n")
+      } else {
+        cat(prm, "= <function>\n")
+      }
     }
   }
 

--- a/man/generate_random_params.Rd
+++ b/man/generate_random_params.Rd
@@ -35,8 +35,27 @@ The function used inside \code{random_params} must be 0 argument functions
 returning a valid value for the parameter with the same name.
 }
 
+\section{\code{param_random_set}}{
+
+The \code{random_params} list can optionnally contain a
+\code{param_random_set} element. It must be a \code{data.frame} of possible
+values to be used as parameters.
+
+The column names must correspond either to:
+the name of one parameter if this parameter is of size 1 or the name of the
+parameter with "_1", "_2", "_N" with the second part being the position of
+the value for a parameter of size > 1. This means that the parameter names
+cannot contain any underscore "_" if you indend to use \code{param_random_set}
+
+The point of the \code{param_random_set} \code{data.frame} is to allow the
+random parameters to be correlated. To achieve this, a whole row of the
+\code{data.frame} is selected for each simulation.
+}
+
 \examples{
 \dontrun{
+
+## Example with only the generator function
 
 # Define random parameter list
 my_randoms <- list(
@@ -64,6 +83,41 @@ param <- param.net(tx.prob = 0.3, random.params = my_randoms)
 paramDraw <- generate_random_params(param, verbose = TRUE)
 paramDraw
 
-}
 
+## Addition of the `param_random_set` `data.frame`
+
+# This function will generate sets of correlated parameters
+ generate_correlated_params <- function() {
+   param.unique <- runif(1)
+   param.set.1 <- param.unique + runif(2)
+   param.set.2 <- param.unique * rnorm(3)
+
+   return(list(param.unique, param.set.1, param.set.2))
+ }
+
+ # Data.frame set of random parameters :
+ correlated_params <- t(replicate(10, unlist(generate_correlated_params())))
+ correlated_params <- as.data.frame(correlated_params)
+ colnames(correlated_params) <- c(
+   "param.unique",
+   "param.set.1_1", "param.set.1_2",
+   "param.set.2_1", "param.set.2_2", "param.set.2_3"
+ )
+
+# Define random parameter list with the `param_random_set` element
+my_randoms <- list(
+  act.rate = param_random(c(0.25, 0.5, 0.75)),
+  param_random_set = correlated_params
+)
+
+# Parameter model with fixed and random parameters
+param <- param.net(inf.prob = 0.3, random.params = my_randoms)
+
+# Parameters are drawn automatically in netsim by calling the function
+# within netsim_loop. Demonstrating draws here but this is not used by
+# end user.
+paramDraw <- generate_random_params(param, verbose = TRUE)
+paramDraw
+
+}
 }

--- a/tests/testthat/test-random-params.R
+++ b/tests/testthat/test-random-params.R
@@ -31,5 +31,52 @@ test_that("Random parameters generators", {
 
   param <- param.net(inf.prob = 0.3, random.params = list(1))
   expect_error(generate_random_params(param))
+
+
+  generate_correlated_params <- function() {
+    param.unique <- runif(1)
+    param.set.1 <- param.unique + runif(2)
+    param.set.2 <- param.unique * rnorm(3)
+
+    return(list(param.unique, param.set.1, param.set.2))
+  }
+
+  # Data.frame set of random parameters :
+  correlated_params <- t(replicate(10, unlist(generate_correlated_params())))
+  correlated_params <- as.data.frame(correlated_params)
+  colnames(correlated_params) <- c(
+    "param.unique",
+    "param.set.1_1", "param.set.1_2",
+    "param.set.2_1", "param.set.2_2", "param.set.2_3"
+  )
+
+  randoms <- c(my_randoms, list(param_random_set = correlated_params))
+  param <- param.net(inf.prob = 0.3, acte.rate = 0.1, random.params = randoms)
+  expect_silent(generate_random_params(param))
+
+  # duplicated `act.rate` random definition
+  colnames(correlated_params) <- c(
+    "act.rate",
+    "param.set.1_1", "param.set.1_2",
+    "param.set.2_1", "param.set.2_2", "param.set.2_3"
+  )
+  randoms <- c(my_randoms, list(param_random_set = correlated_params))
+  param <- param.net(inf.prob = 0.3, acte.rate = 0.1, random.params = randoms)
+  expect_warning(generate_random_params(param))
+
+  # malformed name "param_set.1_1"
+  colnames(correlated_params) <- c(
+    "act.rate",
+    "param_set.1_1", "param.set.1_2",
+    "param.set.2_1", "param.set.2_2", "param.set.2_3"
+  )
+  randoms <- c(my_randoms, list(param_random_set = correlated_params))
+  param <- param.net(inf.prob = 0.3, acte.rate = 0.1, random.params = randoms)
+  expect_error(generate_random_params(param))
+
+  # param_random_set not a data.frame
+  randoms <- c(my_randoms, list(param_random_set = list()))
+  param <- param.net(inf.prob = 0.3, acte.rate = 0.1, random.params = randoms)
+  expect_error(generate_random_params(param))
 })
 

--- a/tests/testthat/test-random-params.R
+++ b/tests/testthat/test-random-params.R
@@ -20,7 +20,7 @@ test_that("Random parameters generators", {
   expect_message(generate_random_params(param, verbose = TRUE))
   expect_silent(generate_random_params(param, verbose = FALSE))
 
-  param <- param.net(inf.prob = 0.3, acte.rate = 0.1)
+  param <- param.net(inf.prob = 0.3, act.rate = 0.1)
   expect_equal(generate_random_params(param), param)
 
   param <- param.net(inf.prob = 0.3, random.params = list())
@@ -51,7 +51,7 @@ test_that("Random parameters generators", {
   )
 
   randoms <- c(my_randoms, list(param_random_set = correlated_params))
-  param <- param.net(inf.prob = 0.3, acte.rate = 0.1, random.params = randoms)
+  param <- param.net(inf.prob = 0.3, act.rate = 0.1, random.params = randoms)
   expect_silent(generate_random_params(param))
 
   # duplicated `act.rate` random definition
@@ -61,7 +61,7 @@ test_that("Random parameters generators", {
     "param.set.2_1", "param.set.2_2", "param.set.2_3"
   )
   randoms <- c(my_randoms, list(param_random_set = correlated_params))
-  param <- param.net(inf.prob = 0.3, acte.rate = 0.1, random.params = randoms)
+  param <- param.net(inf.prob = 0.3, act.rate = 0.1, random.params = randoms)
   expect_warning(generate_random_params(param))
 
   # malformed name "param_set.1_1"
@@ -71,12 +71,12 @@ test_that("Random parameters generators", {
     "param.set.2_1", "param.set.2_2", "param.set.2_3"
   )
   randoms <- c(my_randoms, list(param_random_set = correlated_params))
-  param <- param.net(inf.prob = 0.3, acte.rate = 0.1, random.params = randoms)
+  param <- param.net(inf.prob = 0.3, act.rate = 0.1, random.params = randoms)
   expect_error(generate_random_params(param))
 
   # param_random_set not a data.frame
   randoms <- c(my_randoms, list(param_random_set = list()))
-  param <- param.net(inf.prob = 0.3, acte.rate = 0.1, random.params = randoms)
+  param <- param.net(inf.prob = 0.3, act.rate = 0.1, random.params = randoms)
   expect_error(generate_random_params(param))
 })
 

--- a/vignettes/Random-parameterization-interface.Rmd
+++ b/vignettes/Random-parameterization-interface.Rmd
@@ -1,0 +1,198 @@
+---
+title: "Random-parameterization-interface"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Random-parameterization-interface}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+```{r setup, echo = FALSE}
+library(EpiModel)
+set.seed(1)
+```
+
+# Introduction
+
+When working with network models, EpiModel offers an interface to include
+random parameters. These might include a vector of potential parameter values
+or a statistical distribution definition; in either case, one draw from the
+generator would be completed per individual simulation.
+
+# The model
+
+First, we define a minimal dummy model. If this code does not make sense, please
+check the [EpiModel tutorials](http://www.epimodel.org/tut.html).
+
+```{r model}
+nw <- network_initialize(n = 50)
+
+est <- netest(
+  nw, formation = ~edges,
+  target.stats = c(25),
+  coef.diss = dissolution_coefs(~offset(edges), 10, 0),
+  verbose = FALSE
+)
+
+
+param <- param.net(
+  inf.prob = 0.3,
+  act.rate = 0.5,
+  dummy.param = 4,
+  dummy.strat.param = c(0, 1)
+)
+
+init <- init.net(i.num = 10)
+control <- control.net(type = "SI", nsims = 1, nsteps = 5, verbose = FALSE)
+mod <- netsim(est, param, init, control)
+mod
+```
+
+In the parameter we set the value for `inf.prob` and `act.rate` as usual but
+also define `dummy.param` and `dummy.strat.param`. These last 2 parameters are
+not used by the model but will serve to illustrate random parameters and how to
+handle stratified parameters. `dummy.strat.param` has two elements, this is
+usually used to stratify a parameter by subpopulation.
+
+The last line print a summary of the model and in it we can see the value of the
+parameters under the "Fixed Parameters" section. Note the additional `groups`
+parameter defined automatically by `EpiModel` as part of the "SI" model definition.
+
+# Random parameters
+
+Now we will want our parameters to take random values. For this, we use the
+`random.params` argument to `param.net`. There are two ways of defining which
+parameter to draw randomly and how to draw them.
+
+## Generator functions
+
+The first option is to define a generator function for each parameter we want to
+randomize.
+
+```{r generators}
+my.randoms <- list(
+  act.rate = param_random(c(0.25, 0.5, 0.75)),
+  dummy.param = function() rbeta(1, 1, 2),
+  dummy.strat.param = function() c(
+    rnorm(1, 0.05, 0.01),
+    rnorm(1, 0.15, 0.03)
+  )
+)
+
+param <- param.net(
+  inf.prob = 0.3,
+  random.params = my.randoms
+)
+
+param
+```
+
+Here we kept the `inf.prob` parameter fixed at `0.3` and defined a list
+`my.randoms` containing 3 elements:
+
+- `act.rate` uses the `param_random` [function
+  factory](https://adv-r.hadley.nz/function-factories.html) defined by EpiModel
+  (see `?EpiModel::param_random`).
+- `dummy.param` is a function with no argument that returns a random value from
+  a beta distribution.
+- `dummy.strat.param` is a function with no argument that returns 2 values
+  sampled from normal distributions.
+
+Each element is named after the parameter it will fill and MUST BE a function
+taking no argument and outputting a vector of the right size for the parameter:
+size 1 for `act.rate` and `dummy.param`; size 2 for `dummy.strat.param`.
+
+```{r generators_run}
+control <- control.net(type = "SI", nsims = 3, nsteps = 5, verbose = FALSE)
+mod <- netsim(est, param, init, control)
+
+mod
+```
+
+After running 3 simulations we can see that 2 parameters are still displayed under the
+"Fixed Parameters" section: `inf.prob` and `groups`. The other ones are displayed
+under the "Random Parameters". `act.rate` and `dummy.param` now have 3 values associated
+with them, one per simulation. `dummy.strat.param` have `<list>` as value because
+each simulation has a vector of size 2.
+
+We can inspect the values with:
+
+``` {r generators_inspect}
+str(mod$param$random.params.values)
+```
+
+## Parameter set
+
+The drawback of generator functions is that they cannot produce correlated
+parameters. For instance, we will want `dummy.param` and `dummy.strat.param` to
+be related to one another while allowing `act.rate` to take randomly one of the
+3 values defined above.
+
+We need to define a `data.frame` of the possible values:
+
+```{r set_df}
+n <- 5
+
+related.param <- data.frame(
+  dummy.param = rbeta(n, 1, 2)
+)
+
+related.param$dummy.strat.param_1 <- related.param$dummy.param + rnorm(n)
+related.param$dummy.strat.param_2 <- related.param$dummy.param * 2 + rnorm(n)
+
+related.param
+```
+
+We now have a `data.frame` with 25 rows and 3 columns. Each row contains a set
+of parameters values that will be used together in a model. This way we keep the
+relationship between each value.
+
+The first column of the `data.frame` is named `dummy.param`, similar to the name
+of the parameter. For `dummy.start.param` we need two columns as the parameter
+contains two values. To achieve this, we name the 2 columns `dummy.start.param_1` and
+`dummy.strat.param_2`. The value after the underscore informs `EpiModel` how it
+should combine the values. This in turn means that the underscore symbol is not
+allowed in the parameter names.
+
+Then we set up the rest of the parameters. `related.param` is saved in the
+`my.randoms` list under the special name `param_random_set`.
+
+```{r set_param}
+my.randoms <- list(
+  act.rate = param_random(c(0.25, 0.5, 0.75)),
+  param_random_set = related.param
+
+)
+
+param <- param.net(
+  inf.prob = 0.3,
+  random.params = my.randoms
+)
+
+param
+```
+
+Notice here that we combined a generator function for `act.rate` and a set of
+correlated parameters with `param_random_set`.
+
+```{r set_run}
+control <- control.net(type = "SI", nsims = 3, nsteps = 5, verbose = FALSE)
+mod <- netsim(est, param, init, control)
+
+mod
+```
+
+The output is similar to what we saw with the generator functions.
+
+**Where to get a Parameter set?**
+
+In this example, we generated the parameter set ourselves. In real research, you
+might want to use values coming from elsewhere. As long as you format them as
+described above `EpiModel` will be able to use them.


### PR DESCRIPTION
Initial implementation to close #533 using the `param_random_set` approach.

the following code works:

```r
pkgload::load_all("../EpiModel")

## Example SIR model parameterization with fixed and random parameters
# Network model estimation
nw <- network_initialize(n = 100)
formation <- ~edges
target.stats <- 50
coef.diss <- dissolution_coefs(dissolution = ~offset(edges), duration = 20)
est <- netest(nw, formation, target.stats, coef.diss, verbose = FALSE)

# Defining a parameter generator function
generate_correlated_params <- function() {
  param.unique <- runif(1)
  param.set.1 <- param.unique + runif(2)
  param.set.2 <- param.unique * rnorm(3)

  return(list(param.unique, param.set.1, param.set.2))
}

correlated_params <- t(replicate(10, unlist(generate_correlated_params())))
correlated_params <- as.data.frame(correlated_params)
colnames(correlated_params) <- c(
  "param.unique",
  "param.set.1_1","param.set.1_2",
  "param.set.2_1", "param.set.2_2", "param.set.2_3"
)


param_random_set <- correlated_params
param <- list()


# Defining the list of random parameters
my_randoms <- list(
  act.rate = param_random(c(0.25, 0.5, 0.75)),
  tx.prob = function() rbeta(1, 1, 2),
  stratified.test.rate = function() c(
    rnorm(1, 0.05, 0.01),
    rnorm(1, 0.15, 0.03),
    rnorm(1, 0.25, 0.05)
  ),
  # for correlated parameters, we must define the name of the parameters and
  # the function that will produce them
  param_random_set = correlated_params
)

param <- param.net(rec.rate = 0.02, random.params = my_randoms)

p2 <- generate_random_params(param)

```

# To Do:

- [x] test for obvious edge cases
- [x] document this new implementation
- [x] modify the `print.param` function to correctly display these new parameters (must be finished in order to close #553 with #561)
