### PR TITLE
save _last_unique_id in saveout.net

### DIFF
--- a/R/saveout.R
+++ b/R/saveout.R
@@ -142,6 +142,9 @@ saveout.net <- function(dat, s, out = NULL) {
       out$epi[[names(dat$epi)[j]]] <- data.frame(dat$epi[j])
     }
 
+    out[["_last_unique_id"]] <- list()
+    out[["_last_unique_id"]][[s]] <- dat[["_last_unique_id"]]
+
     out$attr.history <- list()
     out$attr.history[[s]] <- dat$attr.history
 
@@ -209,6 +212,8 @@ saveout.net <- function(dat, s, out = NULL) {
       out$epi[[names(dat$epi)[j]]][, s] <- data.frame(dat$epi[j])
     }
 
+    out[["_last_unique_id"]][[s]] <- dat[["_last_unique_id"]]
+
     out$attr.history[[s]] <- dat$attr.history
     out$raw.records[[s]] <- dat$raw.records
 
@@ -251,6 +256,9 @@ saveout.net <- function(dat, s, out = NULL) {
     for (i in as.vector(which(lapply(out$epi, class) == "data.frame"))) {
       colnames(out$epi[[i]]) <- simnames
     }
+
+    if (length(out[["_last_unique_id"]]) > 0)
+      names(out[["_last_unique_id"]]) <- simnames
 
     if (length(out$attr.history) > 0)
       names(out$attr.history) <- simnames


### PR DESCRIPTION
saves the `_last_unique_id` value in `saveout.net` preventing the duplication of UIDs when restarting a simulation.

NB: `_last_unique_id` will have to be pulled from any `reinit` module for this to work