### PR TITLE
better messages in netsimloop

### DIFF
--- a/R/netsim.R
+++ b/R/netsim.R
@@ -123,7 +123,7 @@
 #'
 netsim <- function(x, param, init, control) {
   check.control.class("net", "EpiModel netsim")
-  
+
   crosscheck.net(x, param, init, control)
   if (!is.null(control[["verbose.FUN"]])) {
     do.call(control[["verbose.FUN"]], list(control, type = "startup"))
@@ -215,12 +215,9 @@ netsim_loop <- function(x, param, init, control, s) {
 
       dat
     },
-    message = function(e) message(netsim_cond_msg("MESSAGE",
-                                                  current_mod, at, e)),
-    warning = function(e) message(netsim_cond_msg("WARNING",
-                                                  current_mod, at, e)),
-    error = function(e) message(netsim_cond_msg("ERROR", current_mod, at, e))
-  )
+    message = function(e) message(netsim_cond_msg("MESSAGE", current_mod, at)),
+    warning = function(e) message(netsim_cond_msg("WARNING", current_mod, at)),
+    error = function(e) message(netsim_cond_msg("ERROR", current_mod, at)))
 
   return(dat)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -297,6 +297,5 @@ apportion_lr <- function(vector.length, values,
 #'
 #' @keywords internal
 netsim_cond_msg <- function(cond, module, at, msg) {
-  paste0("A ", cond, " occured in module '", module,
-         "' at step ", at, ": \n\t", msg)
+  paste0("\n\tA ", cond, " occured in module '", module, "' at step ", at)
 }


### PR DESCRIPTION
small PR to update the messages in `netsimloop`

the previous implementation would print this:

```
A MESSAGE occured in module 'updater.FUN' at step 3381:
        simpleMessage in message("\n\nAt timestep = ", at, " the following param
eters where modified:", :

At timestep = 3381 the following parameters where modified:
'prep.start.prob'




At timestep = 3381 the following parameters where modified:
'prep.start.prob'
A MESSAGE occured in module 'updater.FUN' at step 3433:
        simpleMessage in message("\n\nAt timestep = ", at, " the following param
eters where modified:", :

At timestep = 3433 the following parameters where modified:
'prep.start.prob'




At timestep = 3433 the following parameters where modified:
'prep.start.prob'
```

and the new one:

```

        A MESSAGE occured in module 'updater.FUN' at step 3381


At timestep = 3381 the following parameters where modified:
'prep.start.prob'

        A MESSAGE occured in module 'updater.FUN' at step 3433


At timestep = 3433 the following parameters where modified:
'prep.start.prob'

```

So no more duplication and a bit more clarity with the indentation on the first part

Note: the error message itself does not always contains the timestep